### PR TITLE
구독 API 연결

### DIFF
--- a/Ppap/app/build.gradle.kts
+++ b/Ppap/app/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
     testImplementation("io.ktor:ktor-client-mock:2.3.3")
     implementation("org.slf4j:slf4j-simple:1.7.32")
     implementation("io.ktor:ktor-client-auth:2.3.3")
+    implementation("io.ktor:ktor-client-encoding:2.3.3")
+
     // hilt
     implementation("com.google.dagger:hilt-android:2.47")
     kapt("com.google.dagger:hilt-compiler:2.47")

--- a/Ppap/app/src/androidTest/java/com/jeongg/ppap/presentation/SubscribeComposeTest.kt
+++ b/Ppap/app/src/androidTest/java/com/jeongg/ppap/presentation/SubscribeComposeTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.jeongg.ppap.data.subscribe.dto.SubscribeGetResponseDTO
 import com.jeongg.ppap.presentation.subscribe.CustomSubscribe
 import com.jeongg.ppap.presentation.subscribe.CustomSubscribeItem
 import com.jeongg.ppap.presentation.subscribe.DefaultSubscribeItem
@@ -47,25 +48,20 @@ class SubscribeComposeTest {
     fun subscribe_custom_uncheckedToggle(){
         val isSelected = false
         start_custom_subscribe_item(isSelected)
-
         unchecked.assertIsDisplayed()
         checked.assertDoesNotExist()
-
-        unchecked.performClick() // checked -> unchecked
-
-        checked.assertIsDisplayed()
-        unchecked.assertDoesNotExist()
     }
     @Test
     fun subscribe_emptyItem(){
-        val subscribes = emptyList<String>()
+        val subscribes = emptyList<SubscribeGetResponseDTO>()
         start_custom_subscribe(subscribes)
 
         emptyContent.assertIsDisplayed()
     }
     @Test
     fun subscribe_nonEmptyItem(){
-        val subcribes = listOf("최강 정컴", "전기 최고", "얍")
+        val subcribes = listOf(SubscribeGetResponseDTO(1, "최강 정컴", true),
+                                SubscribeGetResponseDTO(2, "최강 전기", false))
         start_custom_subscribe(subcribes)
 
         emptyContent.assertDoesNotExist()
@@ -73,15 +69,15 @@ class SubscribeComposeTest {
 
     private fun start_default_subscribe_item(isChecked: Boolean = false){
         composeTestRule.setContent {
-            DefaultSubscribeItem(isSelected = isChecked)
+            DefaultSubscribeItem(isActive = isChecked)
         }
     }
     private fun start_custom_subscribe_item(isChecked: Boolean = false){
         composeTestRule.setContent {
-            CustomSubscribeItem(isSelected = isChecked)
+            CustomSubscribeItem(isActive = isChecked)
         }
     }
-    private fun start_custom_subscribe(subscribeList: List<String> = emptyList()){
+    private fun start_custom_subscribe(subscribeList: List<SubscribeGetResponseDTO> = emptyList()){
         composeTestRule.setContent {
             CustomSubscribe(subscribes = subscribeList)
         }

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/SubscribeDataSource.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/SubscribeDataSource.kt
@@ -1,0 +1,50 @@
+package com.jeongg.ppap.data.subscribe
+
+import com.jeongg.ppap.data.subscribe.dto.SubscribeCreateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeGetResponseDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateResponseDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeWithContentDTO
+import com.jeongg.ppap.data.util.ApiUtils
+import com.jeongg.ppap.data.util.HttpRoutes
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+
+class SubscribeDataSource(
+    private val client: HttpClient
+): SubscribeService {
+
+    override suspend fun createSubscribe(subscribeCreateRequestDTO: SubscribeCreateRequestDTO): ApiUtils.ApiResult<String>{
+        return client.post(HttpRoutes.CREATE_SUBSCRIBE){
+            setBody(subscribeCreateRequestDTO)
+        }.body()
+    }
+
+    override suspend fun getSubscribes(): ApiUtils.ApiResult<List<SubscribeGetResponseDTO>>{
+        return client.get(HttpRoutes.GET_SUBSCRIBES).body()
+    }
+
+    override suspend fun getSubscribeById(subscribeId: Long): ApiUtils.ApiResult<SubscribeWithContentDTO> {
+        return client.get(HttpRoutes.GET_SUBSCRIBE + "/$subscribeId").body()
+    }
+
+    override suspend fun updateSubscribe(
+        subscribeId: Long,
+        subscribeUpdateRequestDTO: SubscribeUpdateRequestDTO
+    ): ApiUtils.ApiResult<SubscribeUpdateResponseDTO>{
+        return client.post(HttpRoutes.UPDATE_SUBSCRIBE + "/$subscribeId"){
+            setBody(subscribeUpdateRequestDTO)
+        }.body()
+    }
+
+    override suspend fun deleteSubscribe(subscribeId: Long): ApiUtils.ApiResult<String>{
+        return client.post(HttpRoutes.DELETE_SUBSCRIBE + "/$subscribeId"){}.body()
+    }
+
+    override suspend fun updateActive(subscribeId: Long): ApiUtils.ApiResult<SubscribeUpdateResponseDTO>{
+        return client.post(HttpRoutes.UPDATE_ACTIVE + "/$subscribeId"){}.body()
+    }
+}

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/SubscribeRepository.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/SubscribeRepository.kt
@@ -1,0 +1,70 @@
+package com.jeongg.ppap.data.subscribe
+
+import com.jeongg.ppap.data.subscribe.dto.SubscribeCreateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeGetResponseDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateResponseDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeWithContentDTO
+import com.jeongg.ppap.data.util.ApiUtils
+import com.jeongg.ppap.data.util.getErrorMessage
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SubscribeRepository @Inject constructor(
+    private val subscribeService: SubscribeService
+){
+    suspend fun createSubscribe(subscribeCreateRequestDTO: SubscribeCreateRequestDTO): ApiUtils.ApiResult<String> {
+        return try {
+            subscribeService.createSubscribe(subscribeCreateRequestDTO)
+        } catch(e: Exception){
+            val error = getErrorMessage(e)
+            ApiUtils.ApiResult(false, null, ApiUtils.ApiError(error.first, error.second))
+        }
+    }
+
+    suspend fun getSubscribes(): ApiUtils.ApiResult<List<SubscribeGetResponseDTO>>{
+        return try {
+            subscribeService.getSubscribes()
+        } catch(e: Exception){
+            val error = getErrorMessage(e)
+            ApiUtils.ApiResult(false, null, ApiUtils.ApiError(error.first, error.second))
+        }
+    }
+
+    suspend fun getSubscribeById(subscribeId: Long): ApiUtils.ApiResult<SubscribeWithContentDTO>{
+        return try {
+            subscribeService.getSubscribeById(subscribeId)
+        } catch(e: Exception){
+            val error = getErrorMessage(e)
+            ApiUtils.ApiResult(false, null, ApiUtils.ApiError(error.first, error.second))
+        }
+    }
+
+    suspend fun updateSubscribe(subscribeId: Long, subscribeUpdateRequestDTO: SubscribeUpdateRequestDTO): ApiUtils.ApiResult<SubscribeUpdateResponseDTO>{
+        return try {
+            subscribeService.updateSubscribe(subscribeId, subscribeUpdateRequestDTO)
+        } catch(e: Exception){
+            val error = getErrorMessage(e)
+            ApiUtils.ApiResult(false, null, ApiUtils.ApiError(error.first, error.second))
+        }
+    }
+
+    suspend fun deleteSubscribe(subscribeId: Long): ApiUtils.ApiResult<String>{
+        return try {
+            subscribeService.deleteSubscribe(subscribeId)
+        } catch(e: Exception){
+            val error = getErrorMessage(e)
+            ApiUtils.ApiResult(false, null, ApiUtils.ApiError(error.first, error.second))
+        }
+    }
+
+    suspend fun updateActive(subscribeId: Long): ApiUtils.ApiResult<SubscribeUpdateResponseDTO>{
+        return try {
+            subscribeService.updateActive(subscribeId)
+        } catch(e: Exception){
+            val error = getErrorMessage(e)
+            ApiUtils.ApiResult(false, null, ApiUtils.ApiError(error.first, error.second))
+        }
+    }
+}

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/SubscribeService.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/SubscribeService.kt
@@ -1,0 +1,17 @@
+package com.jeongg.ppap.data.subscribe
+
+import com.jeongg.ppap.data.subscribe.dto.SubscribeCreateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeGetResponseDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateResponseDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeWithContentDTO
+import com.jeongg.ppap.data.util.ApiUtils
+
+interface SubscribeService {
+    suspend fun createSubscribe(subscribeCreateRequestDTO: SubscribeCreateRequestDTO): ApiUtils.ApiResult<String>
+    suspend fun getSubscribes(): ApiUtils.ApiResult<List<SubscribeGetResponseDTO>>
+    suspend fun getSubscribeById(subscribeId: Long): ApiUtils.ApiResult<SubscribeWithContentDTO>
+    suspend fun updateSubscribe(subscribeId: Long, subscribeUpdateRequestDTO: SubscribeUpdateRequestDTO): ApiUtils.ApiResult<SubscribeUpdateResponseDTO>
+    suspend fun deleteSubscribe(subscribeId: Long): ApiUtils.ApiResult<String>
+    suspend fun updateActive(subscribeId: Long): ApiUtils.ApiResult<SubscribeUpdateResponseDTO>
+}

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeCreateRequestDTO.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeCreateRequestDTO.kt
@@ -1,0 +1,10 @@
+package com.jeongg.ppap.data.subscribe.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SubscribeCreateRequestDTO(
+    val title: String,
+    val rssLink: String,
+    val noticeLink: String?
+)

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeGetResponseDTO.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeGetResponseDTO.kt
@@ -1,0 +1,10 @@
+package com.jeongg.ppap.data.subscribe.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SubscribeGetResponseDTO(
+    val subscribeId: Long,
+    val title: String,
+    val isActive: Boolean
+)

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeUpdateRequestDTO.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeUpdateRequestDTO.kt
@@ -1,0 +1,9 @@
+package com.jeongg.ppap.data.subscribe.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SubscribeUpdateRequestDTO(
+    val title: String,
+    val noticeLink: String?,
+)

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeUpdateResponseDTO.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeUpdateResponseDTO.kt
@@ -1,0 +1,11 @@
+package com.jeongg.ppap.data.subscribe.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SubscribeUpdateResponseDTO(
+    val subscribeId: Long,
+    val title: String,
+    val noticeLink: String?,
+    val isActive: Boolean
+)

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeWithContentDTO.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/subscribe/dto/SubscribeWithContentDTO.kt
@@ -1,0 +1,12 @@
+package com.jeongg.ppap.data.subscribe.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SubscribeWithContentDTO(
+    val subscribeId: Long,
+    val title: String,
+    val noticeLink: String?,
+    val rssLink: String,
+    val isActive: Boolean
+)

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/user/dto/RefreshTokenDTO.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/user/dto/RefreshTokenDTO.kt
@@ -4,5 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RefreshTokenDTO(
-    val refreshTokenDTO: String
+    val refreshToken: String
 )

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/util/HttpRoutes.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/util/HttpRoutes.kt
@@ -1,9 +1,15 @@
 package com.jeongg.ppap.data.util
 
 object HttpRoutes {
-    private const val BASE_URL = "http://192.168.219.100:8080"
-    const val KAKAO_LOGIN = "$BASE_URL/auth/kakao/login"
-    const val KAKAO_REISSUE = "$BASE_URL/auth/reissue"
-    const val LOGOUT = "$BASE_URL/auth/logout"
-    const val WITHDRAWL = "$BASE_URL/auth/withdrawl"
+    const val BASE_URL = "http://192.168.219.100:8080"
+    const val KAKAO_LOGIN = "/auth/kakao/login"
+    const val KAKAO_REISSUE = "/auth/reissue"
+    const val LOGOUT = "/auth/logout"
+    const val WITHDRAWL = "/auth/withdrawl"
+    const val CREATE_SUBSCRIBE = "/subscribe"
+    const val GET_SUBSCRIBES = "/subscribe"
+    const val GET_SUBSCRIBE = "/subscribe"
+    const val UPDATE_SUBSCRIBE = "/subscribe"
+    const val DELETE_SUBSCRIBE = "/subscribe/delete"
+    const val UPDATE_ACTIVE = "/subscribe/active"
 }

--- a/Ppap/app/src/main/java/com/jeongg/ppap/data/util/PDataStore.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/data/util/PDataStore.kt
@@ -20,7 +20,7 @@ class PDataStore @Inject constructor(@ApplicationContext val context: Context) {
     }
     fun getData(key: String): String {
         return runBlocking(Dispatchers.IO){
-            store.data.map{ it[stringPreferencesKey(key)] ?: "null" }.first()
+            store.data.map{ it[stringPreferencesKey(key)] ?: "" }.first()
         }
     }
 }
@@ -28,4 +28,3 @@ class PDataStore @Inject constructor(@ApplicationContext val context: Context) {
 const val FCM_TOKEN_KEY = "fcm-token"
 const val ACCESS_TOKEN_KEY = "access-token"
 const val REFRESH_TOKEN_KEY = "refresh-token"
-const val KAKAO_TOKEN_KEY = "kakao-token"

--- a/Ppap/app/src/main/java/com/jeongg/ppap/di/NetworkModule.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/di/NetworkModule.kt
@@ -1,7 +1,10 @@
 package com.jeongg.ppap.di
 
 import android.content.Context
-import androidx.datastore.preferences.core.stringPreferencesKey
+import android.util.Log
+import com.jeongg.ppap.data.subscribe.SubscribeDataSource
+import com.jeongg.ppap.data.subscribe.SubscribeRepository
+import com.jeongg.ppap.data.subscribe.SubscribeService
 import com.jeongg.ppap.data.user.UserDataSource
 import com.jeongg.ppap.data.user.UserRepository
 import com.jeongg.ppap.data.user.UserService
@@ -12,8 +15,6 @@ import com.jeongg.ppap.data.util.ApiUtils
 import com.jeongg.ppap.data.util.HttpRoutes
 import com.jeongg.ppap.data.util.PDataStore
 import com.jeongg.ppap.data.util.REFRESH_TOKEN_KEY
-import com.jeongg.ppap.dataStore
-import com.jeongg.ppap.util.log
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -26,21 +27,18 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.plugins.compression.ContentEncoding
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.request.accept
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import javax.inject.Singleton
 
@@ -52,12 +50,14 @@ class NetworkModule {
     fun provideHttpClient(
         @ApplicationContext context: Context
     ): HttpClient {
-        val accessToken = PDataStore(context).getData(ACCESS_TOKEN_KEY)
-        val refreshToken = PDataStore(context).getData(REFRESH_TOKEN_KEY)
-        "access token : $accessToken \n refresh token: $refreshToken".log()
         return HttpClient(CIO) {
             install(Logging){
-                level = LogLevel.ALL
+                logger = object: Logger {
+                    override fun log(message: String){
+                        Log.d("ppap_api", message)
+                    }
+                }
+                level = LogLevel.HEADERS
             }
             install(ContentNegotiation) {
                 json(Json{
@@ -72,11 +72,17 @@ class NetworkModule {
                 socketTimeoutMillis = 5000
             }
             install(Auth){
+                val refreshToken = PDataStore(context).getData(ACCESS_TOKEN_KEY)
                 bearer {
                     refreshTokens {
                         val token = client.post(HttpRoutes.KAKAO_REISSUE){
                             setBody(RefreshTokenDTO(refreshToken))
                         }.body<ApiUtils.ApiResult<KakaoLoginDTO>>()
+
+                        if (token.success){
+                            PDataStore(context).setData(ACCESS_TOKEN_KEY, token.response?.accessToken ?: "")
+                            PDataStore(context).setData(REFRESH_TOKEN_KEY, token.response?.refreshToken ?: "")
+                        }
                         BearerTokens(
                             accessToken = token.response?.accessToken ?: "",
                             refreshToken = token.response?.refreshToken ?: ""
@@ -84,10 +90,15 @@ class NetworkModule {
                     }
                 }
             }
+            install(ContentEncoding) {
+                deflate(1.0F)
+                gzip(0.9F)
+            }
             defaultRequest{
+                val accessToken = PDataStore(context).getData(ACCESS_TOKEN_KEY)
                 contentType(ContentType.Application.Json)
-                accept(ContentType.Application.Json)
                 if (accessToken.isNotEmpty()) headers.append(HttpHeaders.Authorization, accessToken)
+                url(HttpRoutes.BASE_URL)
             }
         }
     }
@@ -100,6 +111,16 @@ class NetworkModule {
     @Singleton
     fun provideUserRepository(service: UserService): UserRepository {
         return UserRepository(service)
+    }
+    @Provides
+    @Singleton
+    fun provideSubscribeService(client: HttpClient): SubscribeService {
+        return SubscribeDataSource(client)
+    }
+    @Provides
+    @Singleton
+    fun provideSubscribeRepository(service: SubscribeService): SubscribeRepository {
+        return SubscribeRepository(service)
     }
 
 }

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/component/PDialog.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/component/PDialog.kt
@@ -26,7 +26,8 @@ fun PDialog(
     text: String = "정보컴퓨터공학부",
     onDeleteClick:() -> Unit = {},
     onEditClick:() -> Unit = {},
-    onSubscribeClick:() -> Unit = {}
+    onSubscribeClick:() -> Unit = {},
+    isActive: Boolean = true
 ){
     Column(
         verticalArrangement = Arrangement.Center
@@ -61,7 +62,10 @@ fun PDialog(
                 )
             }
         }
-        PButton(text = stringResource(R.string.subscribe_button), onClick = onSubscribeClick)
+        PButton(
+            text = if (isActive) stringResource(R.string.subscribe_delete_button) else stringResource(R.string.subscribe_button),
+            onClick = onSubscribeClick
+        )
     }
 }
 

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/component/PTextField.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/component/PTextField.kt
@@ -10,10 +10,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -26,15 +23,16 @@ import com.jeongg.ppap.presentation.theme.typography
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PTextField(
+    text: String = "",
+    onValueChange: (String) -> Unit = {},
     placeholder: String = "힌트"
 ){
     val focusRequester = remember { FocusRequester() }
-    var text by remember { mutableStateOf("") }
     val interactionSource = remember { MutableInteractionSource() }
 
     BasicTextField(
         value = text,
-        onValueChange = { text = it },
+        onValueChange = onValueChange,
         modifier = Modifier
             .fillMaxWidth()
             .defaultMinSize(minHeight = 40.dp)

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/login/LoginScreen.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/login/LoginScreen.kt
@@ -27,6 +27,7 @@ import com.jeongg.ppap.R
 import com.jeongg.ppap.presentation.component.PDivider
 import com.jeongg.ppap.presentation.navigation.Screen
 import com.jeongg.ppap.presentation.theme.Dimens
+import com.jeongg.ppap.presentation.util.PEvent
 import com.jeongg.ppap.util.log
 import kotlinx.coroutines.flow.collectLatest
 
@@ -39,11 +40,11 @@ fun LoginScreen(
     LaunchedEffect(key1 = true){
         viewModel.eventFlow.collectLatest{ event ->
             when(event){
-                is LoginUiEvent.LoginSuccess -> {
+                is PEvent.SUCCESS -> {
                     navController.popBackStack()
                     navController.navigate(Screen.SubscribeScreen.route)
                 }
-                is LoginUiEvent.LoginFail -> Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                is PEvent.ERROR -> Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 else -> { "로그인 로딩중".log() }
             }
         }

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/login/LoginUiEvent.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/login/LoginUiEvent.kt
@@ -1,7 +1,0 @@
-package com.jeongg.ppap.presentation.login
-
-sealed class LoginUiEvent {
-    object LoginSuccess: LoginUiEvent()
-    data class LoginFail(val message: String): LoginUiEvent()
-    object LoginLoading: LoginUiEvent()
-}

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/navigation/NavGraph.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/navigation/NavGraph.kt
@@ -2,7 +2,9 @@ package com.jeongg.ppap.presentation.navigation
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.jeongg.ppap.presentation.login.LoginScreen
 import com.jeongg.ppap.presentation.notice.NoticeListScreen
 import com.jeongg.ppap.presentation.notice.NoticeScrapScreen
@@ -18,7 +20,17 @@ fun NavGraphBuilder.ppapGraph(
     composable(route = Screen.LoginScreen.route){ LoginScreen(navController)}
     composable(route = Screen.SplashScreen.route){ SplashScreen(navController) }
     composable(route = Screen.SubscribeScreen.route){ SubscribeScreen(navController, upPress) }
-    composable(route = Screen.SubscribeAddScreen.route){ SubscribeAddScreen(navController, upPress) }
+    composable(
+        route = Screen.SubscribeAddScreen.route + "?subscribeId={subscribeId}",
+        arguments = listOf(
+            navArgument("subscribeId"){
+                type = NavType.LongType
+                defaultValue = -1L
+            },
+        )
+    ){
+        SubscribeAddScreen(navController, upPress)
+    }
     composable(route = Screen.NoticeListScreen.route){ NoticeListScreen(navController)}
     composable(route = Screen.NoticeScrapScreen.route){ NoticeScrapScreen(navController, upPress)}
     composable(route = Screen.SettingScreen.route){ SettingScreen(navController, upPress)}

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/notice/NoticeListScreen.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/notice/NoticeListScreen.kt
@@ -74,9 +74,9 @@ fun NoticeListBanner(
     val state = rememberPagerState(initialPage = 0) { 3 }
     val colors = listOf(very_bright_yellow, bright_pink, main_green)
     val images = listOf(R.drawable.pineapple, R.drawable.apple_no_background, R.drawable.pineapple)
-    val titles = listOf(R.string.banner_title1, R.string.banner_title2, R.string.banner_title3)
-    val descriptions = listOf(R.string.banner_description1,R.string.banner_description2, R.string.banner_description3)
-    val screens = listOf(Screen.NoticeScrapScreen.route, Screen.SubscribeAddScreen.route, Screen.SubscribeScreen.route)
+    val titles = listOf(R.string.banner_title2, R.string.banner_title3, R.string.banner_title1)
+    val descriptions = listOf(R.string.banner_description2, R.string.banner_description3, R.string.banner_description1)
+    val screens = listOf(Screen.SubscribeAddScreen.route, Screen.SubscribeScreen.route, Screen.NoticeScrapScreen.route)
 
     HorizontalPager(
         state = state,

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/setting/SettingScreen.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/setting/SettingScreen.kt
@@ -59,6 +59,7 @@ fun SettingScreen(
             item {
                 ServiceScreen(
                     onSubscribe = {navController.navigate(Screen.SubscribeScreen.route)},
+                    onSubscribeAdd = {navController.navigate(Screen.SubscribeAddScreen.route)},
                     onScrap = {navController.navigate(Screen.NoticeScrapScreen.route)}
                 )
             }
@@ -112,6 +113,7 @@ fun MyPageScreen() {
 @Composable
 fun ServiceScreen(
     onSubscribe: () -> Unit = {},
+    onSubscribeAdd: () -> Unit = {},
     onScrap: () -> Unit = {}
 ) {
     Column(
@@ -123,7 +125,8 @@ fun ServiceScreen(
             style = MaterialTheme.typography.titleSmall,
             color = Color.Black,
         )
-        SettingItem(stringResource(R.string.subscribe_edit_add), onSubscribe)
+        SettingItem(stringResource(R.string.subscribe_get), onSubscribe)
+        SettingItem(stringResource(R.string.subscribe_add), onSubscribeAdd)
         SettingItem(stringResource(R.string.scrap), onScrap)
         SettingItem(stringResource(R.string.version_open_source))
     }

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/splash/SplashViewModel.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/splash/SplashViewModel.kt
@@ -1,7 +1,7 @@
 package com.jeongg.ppap.presentation.splash
 
 import androidx.lifecycle.ViewModel
-import com.jeongg.ppap.data.util.KAKAO_TOKEN_KEY
+import com.jeongg.ppap.data.util.ACCESS_TOKEN_KEY
 import com.jeongg.ppap.data.util.PDataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -12,7 +12,7 @@ class SplashViewModel @Inject constructor(
 ):ViewModel() {
 
     fun isUserLoggedIn(): Boolean{
-        val token = dataStore.getData(KAKAO_TOKEN_KEY)
+        val token = dataStore.getData(ACCESS_TOKEN_KEY)
         return token.isNotBlank()
     }
 

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeAddEvent.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeAddEvent.kt
@@ -1,0 +1,8 @@
+package com.jeongg.ppap.presentation.subscribe
+
+sealed class SubscribeAddEvent{
+    data class EnteredTitle(val title: String): SubscribeAddEvent()
+    data class EnteredNoticeLink(val notice: String?): SubscribeAddEvent()
+    data class EnteredRssLink(val rss: String): SubscribeAddEvent()
+    object SaveSubscribe: SubscribeAddEvent()
+}

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeAddViewModel.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeAddViewModel.kt
@@ -1,0 +1,130 @@
+package com.jeongg.ppap.presentation.subscribe
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jeongg.ppap.data.subscribe.SubscribeRepository
+import com.jeongg.ppap.data.subscribe.dto.SubscribeCreateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateRequestDTO
+import com.jeongg.ppap.presentation.util.PEvent
+import com.jeongg.ppap.util.log
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SubscribeAddViewModel @Inject constructor(
+    private val subscribeRepository: SubscribeRepository,
+    private val savedStateHandle: SavedStateHandle
+): ViewModel() {
+
+    private var subscribeId = mutableLongStateOf(-1L)
+
+    private val _title = mutableStateOf("")
+    val title = _title
+
+    private val _noticeLink: MutableState<String?> = mutableStateOf(null)
+    val noticeLink = _noticeLink
+
+    private val _rssLink = mutableStateOf("")
+    val rssLink = _rssLink
+
+    private val _eventFlow = MutableSharedFlow<PEvent>()
+    val eventFlow = _eventFlow
+
+    init {
+        savedStateHandle.get<Long>("subscribeId")?.let{
+            subscribeId.longValue = it
+        }
+        if(subscribeId.longValue >= 0) getSubscribe()
+        "SubscribeId: ${subscribeId.longValue}".log()
+    }
+
+    fun isUpdate(): Boolean {
+        return subscribeId.longValue >= 0
+    }
+
+    fun onEvent(event: SubscribeAddEvent){
+        when (event){
+            is SubscribeAddEvent.EnteredTitle -> {
+                _title.value = event.title
+            }
+            is SubscribeAddEvent.EnteredNoticeLink -> {
+                _noticeLink.value = event.notice
+            }
+            is SubscribeAddEvent.EnteredRssLink -> {
+                _rssLink.value = event.rss
+            }
+            is SubscribeAddEvent.SaveSubscribe -> {
+                if (subscribeId.longValue < 0) saveSubscribe()
+                else updateSubscribe()
+            }
+        }
+    }
+    private fun saveSubscribe(){
+        viewModelScope.launch {
+            if (title.value.isEmpty() || rssLink.value.isEmpty()){
+                _eventFlow.emit(PEvent.ERROR("제목과 rss 링크는 비어있으면 안됩니다."))
+                return@launch
+            }
+            _eventFlow.emit(PEvent.LOADING)
+            val response = subscribeRepository.createSubscribe(
+                SubscribeCreateRequestDTO(
+                    title = title.value,
+                    noticeLink = noticeLink.value?.ifBlank { null },
+                    rssLink = rssLink.value
+                )
+            )
+            if (response.success){
+                _eventFlow.emit(PEvent.ADD)
+            } else {
+                "구독 저장 실패 ${response.error?.status} ${noticeLink.value.isNullOrBlank()}".log()
+                _eventFlow.emit(PEvent.ERROR("${response.error?.message}"))
+            }
+        }
+    }
+
+    private fun updateSubscribe(){
+        viewModelScope.launch {
+            if (title.value.isEmpty()){
+                _eventFlow.emit(PEvent.ERROR("제목은 비어있으면 안됩니다."))
+                return@launch
+            }
+            _eventFlow.emit(PEvent.LOADING)
+            val response = subscribeRepository.updateSubscribe(
+                subscribeId = subscribeId.longValue,
+                subscribeUpdateRequestDTO = SubscribeUpdateRequestDTO(
+                    title = title.value,
+                    noticeLink = noticeLink.value?.ifBlank { null }
+                )
+            )
+            if (response.success){
+                _eventFlow.emit(PEvent.UPDATE)
+            } else {
+                "구독 업데이트 실패 ${response.error?.status}".log()
+                _eventFlow.emit(PEvent.ERROR("${response.error?.message}"))
+            }
+        }
+    }
+
+    private fun getSubscribe(){
+        viewModelScope.launch{
+            _eventFlow.emit(PEvent.LOADING)
+            val response = subscribeRepository.getSubscribeById(subscribeId.longValue)
+            if (response.success){
+                _title.value = response.response?.title ?: ""
+                _noticeLink.value = response.response?.noticeLink
+                _rssLink.value = response.response?.rssLink ?: ""
+                _eventFlow.emit(PEvent.GET)
+            } else {
+                "불러오기 실패 ${response.error?.message}".log()
+                _eventFlow.emit(PEvent.ERROR("구독 정보를 불러오는데 실패하였습니다."))
+            }
+        }
+    }
+}
+

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeViewModel.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeViewModel.kt
@@ -36,7 +36,7 @@ class SubscribeViewModel @Inject constructor(
                 _eventFlow.emit(PEvent.SUCCESS)
             } else {
                 "구독 활성화 실패 ${response.error?.status}".log()
-                _eventFlow.emit(PEvent.ERROR("구독 활성화 실패하였습니다."))
+                _eventFlow.emit(PEvent.ERROR(response.error?.message ?: "구독 활성화 실패하였습니다."))
             }
         }
     }
@@ -48,7 +48,7 @@ class SubscribeViewModel @Inject constructor(
                 _eventFlow.emit(PEvent.DELETE)
             } else {
                 "구독 삭제 실패 ${response.error?.status}".log()
-                _eventFlow.emit(PEvent.ERROR("구독 삭제 실패하였습니다."))
+                _eventFlow.emit(PEvent.ERROR(response.error?.message ?: "구독 삭제 실패하였습니다."))
             }
         }
     }
@@ -61,7 +61,7 @@ class SubscribeViewModel @Inject constructor(
                 _eventFlow.emit(PEvent.GET)
             } else {
                 "구독 목록 불러오기 실패 ${response.error?.status}".log()
-                _eventFlow.emit(PEvent.ERROR("구독 목록을 불러오는데 실패하였습니다."))
+                _eventFlow.emit(PEvent.ERROR(response.error?.message ?: "구독 목록 조회를 실패했습니다."))
             }
         }
     }

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeViewModel.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/subscribe/SubscribeViewModel.kt
@@ -1,0 +1,68 @@
+package com.jeongg.ppap.presentation.subscribe
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jeongg.ppap.data.subscribe.SubscribeRepository
+import com.jeongg.ppap.data.subscribe.dto.SubscribeGetResponseDTO
+import com.jeongg.ppap.presentation.util.PEvent
+import com.jeongg.ppap.util.log
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SubscribeViewModel @Inject constructor(
+    private val subscribeRepository: SubscribeRepository,
+): ViewModel()  {
+
+    private var _customSubscribes = mutableStateOf<List<SubscribeGetResponseDTO>>(emptyList())
+    val customSubscribes = _customSubscribes
+
+    private val _eventFlow = MutableSharedFlow<PEvent>()
+    val eventFlow = _eventFlow
+
+    init {
+        getSubscribes()
+    }
+
+    fun updateActive(subscribeId: Long){
+        viewModelScope.launch {
+            _eventFlow.emit(PEvent.LOADING)
+            val response = subscribeRepository.updateActive(subscribeId)
+            if (response.success){
+                "구독 활성화 성공".log()
+                _eventFlow.emit(PEvent.SUCCESS)
+            } else {
+                "구독 활성화 실패 ${response.error?.status}".log()
+                _eventFlow.emit(PEvent.ERROR("구독 활성화 실패하였습니다."))
+            }
+        }
+    }
+    fun deleteSubscribe(subscribeId: Long){
+        viewModelScope.launch {
+            _eventFlow.emit(PEvent.LOADING)
+            val response = subscribeRepository.deleteSubscribe(subscribeId)
+            if (response.success){
+                _eventFlow.emit(PEvent.DELETE)
+            } else {
+                "구독 삭제 실패 ${response.error?.status}".log()
+                _eventFlow.emit(PEvent.ERROR("구독 삭제 실패하였습니다."))
+            }
+        }
+    }
+    fun getSubscribes(){
+        viewModelScope.launch {
+            _eventFlow.emit(PEvent.LOADING)
+            val response = subscribeRepository.getSubscribes()
+            if (response.success){
+                _customSubscribes.value = response.response ?: emptyList()
+                _eventFlow.emit(PEvent.GET)
+            } else {
+                "구독 목록 불러오기 실패 ${response.error?.status}".log()
+                _eventFlow.emit(PEvent.ERROR("구독 목록을 불러오는데 실패하였습니다."))
+            }
+        }
+    }
+}

--- a/Ppap/app/src/main/java/com/jeongg/ppap/presentation/util/PEvent.kt
+++ b/Ppap/app/src/main/java/com/jeongg/ppap/presentation/util/PEvent.kt
@@ -1,0 +1,12 @@
+package com.jeongg.ppap.presentation.util
+
+sealed class PEvent{
+    object SUCCESS: PEvent()
+    object GET: PEvent()
+    object UPDATE: PEvent()
+    object ADD: PEvent()
+    object DELETE: PEvent()
+    object LOADING: PEvent()
+
+    data class ERROR(val message: String): PEvent()
+}

--- a/Ppap/app/src/main/res/values/strings.xml
+++ b/Ppap/app/src/main/res/values/strings.xml
@@ -14,9 +14,10 @@
     <string name="remove">삭제하기</string>
     <string name="add_subscribe_description">다음 정보를 입력하여 학과 게시판, 채용 게시판 등 필요한 정보를 빠르게 알림으로 받아보세요!</string>
     <string name="add_subscribe_title">구독 추가하기</string>
+    <string name="update_subscribe_title">구독 수정하기</string>
     <string name="add_subscribe_button_text">공지사항 등록하기</string>
-    <string name="explain1">1. 원하는 홈페이지 접속 (예: 정컴 공지사항) \n2. 공지 링크 및 RSS 링크 확인\n\t(다음 탭 확인)</string>
-    <string name="explain2">주의) RSS 링크가 제공되지 않는 홈페이지는 서비스가 불가능합니다.</string>
+    <string name="explain1">1. 원하는 홈페이지 접속 (예: 정컴 공지사항) \n2. 공지 링크 및 RSS 링크 확인</string>
+    <string name="explain2">(주의) RSS 링크는 수정 불가능합니다.\n RSS 링크가 제공되지 않는 홈페이지는 서비스가 불가능합니다.</string>
     <string name="subscribe_field_title">구독 제목</string>
     <string name="subscribe_field_link">공지사항 링크</string>
     <string name="subscribe_field_rss">RSS 링크</string>
@@ -36,11 +37,16 @@
     <string name="logout">로그아웃</string>
     <string name="leave_app">회원탈퇴</string>
     <string name="service">서비스</string>
-    <string name="subscribe_edit_add">구독 수정 및 추가하기</string>
+    <string name="subscribe_get">구독한 목록 보기</string>
     <string name="scrap">스크랩</string>
     <string name="version_open_source">버전 및 오픈 소스</string>
     <string name="app_description2">부산대 공지사항 알림 서비스,\nPPAP입니다.</string>
     <string name="delete_button">삭제하기</string>
     <string name="edit_button">수정하기</string>
     <string name="subscribe_button">구독하기</string>
+    <string name="subscribe_delete_button">구독 취소하기</string>
+    <string name="custom_subscribes">내가 추가한 구독</string>
+    <string name="empty_subscribes">새로 추가한\n공지사항이 없습니다</string>
+    <string name="update_subscribe_button_text">공지사항 수정하기</string>
+    <string name="subscribe_add">새로운 구독 추가히기</string>
 </resources>

--- a/Ppap/app/src/test/java/com/jeongg/ppap/SubscribeUnitTest.kt
+++ b/Ppap/app/src/test/java/com/jeongg/ppap/SubscribeUnitTest.kt
@@ -1,0 +1,281 @@
+package com.jeongg.ppap
+
+import com.jeongg.ppap.data.subscribe.SubscribeDataSource
+import com.jeongg.ppap.data.subscribe.dto.SubscribeCreateRequestDTO
+import com.jeongg.ppap.data.subscribe.dto.SubscribeUpdateRequestDTO
+import com.jeongg.ppap.util.getExceptionHttpClient
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Test
+
+class SubscribeUnitTest {
+
+    @Test
+    fun createSubscribe_success(){
+        runBlocking {
+            // given
+            val content = """{"success": true, "response": created, "error": null}"""
+            val subscribe = SubscribeCreateRequestDTO("title", "rssLink", "noticeLink")
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).createSubscribe(subscribe)
+
+            // then
+            Assert.assertEquals(true, data.success)
+            Assert.assertEquals("created", data.response ?: "")
+            Assert.assertEquals(null, data.error)
+        }
+    }
+    @Test
+    fun createSubscribe_fail(){
+        runBlocking {
+            // given
+            val content = """{"success": false, "response": null, "error": {"message": "유효하지 않은 RSS 링크입니다.", "status": 400}}"""
+            val subscribe = SubscribeCreateRequestDTO("title", "rssLink", "noticeLink")
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).createSubscribe(subscribe)
+
+            // then
+            Assert.assertEquals(false, data.success)
+            Assert.assertEquals(null, data.response)
+            Assert.assertEquals(400, data.error?.status ?: 0)
+        }
+    }
+
+    @Test
+    fun getSubscribes_success(){
+        runBlocking {
+            // given
+            val content = """{
+                    "success": true,
+                    "response": [
+                        {
+                            "subscribeId": 1,
+                            "title": "정컴 학부 공지사항",
+                            "isActive": true
+                        },
+                        {
+                            "subscribeId": 2,
+                            "title": "정컴 학부 공지사항",
+                            "isActive": true
+                        }
+                    ],
+                    "error": null
+                }
+                """.trimIndent()
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).getSubscribes()
+
+            // then
+            Assert.assertEquals(true, data.success)
+            Assert.assertEquals(1, data.response?.get(0)?.subscribeId ?: 0)
+            Assert.assertEquals(2, data.response?.size ?: 0)
+            Assert.assertEquals(null, data.error)
+        }
+    }
+    @Test
+    fun getSubscribes_fail(){
+        runBlocking {
+            // given
+            val content = """{"success": false, "response": null, "error": {"message": "빈 구독 목록입니다.", "status": 404}}"""
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).getSubscribes()
+
+            // then
+            Assert.assertEquals(false, data.success)
+            Assert.assertEquals(null, data.response)
+            Assert.assertEquals(404, data.error?.status ?: 0)
+        }
+    }
+
+    @Test
+    fun getSubscribeById_success(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """
+                {
+                    "success": true,
+                    "response": {
+                        "subscribeId": 1,
+                        "title": "테스트1",
+                        "noticeLink": null,
+                        "rssLink": "https://cse.pusan.ac.kr/bbs/cse/2615/rssList.do",
+                        "isActive": true
+                    },
+                    "error": null
+                }
+                """.trimIndent()
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).getSubscribeById(subscribeId)
+
+            // then
+            Assert.assertEquals(true, data.success)
+            Assert.assertEquals(1, data.response?.subscribeId ?: 0)
+            Assert.assertEquals("테스트1", data.response?.title ?: "")
+            Assert.assertEquals(null, data.response?.noticeLink)
+            Assert.assertEquals(null, data.error)
+        }
+    }
+    @Test
+    fun getSubscribeById_fail(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """{"success": false, "response": null, "error": {"message": "빈 구독 목록입니다.", "status": 404}}"""
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).getSubscribeById(subscribeId)
+
+            // then
+            Assert.assertEquals(false, data.success)
+            Assert.assertEquals(null, data.response)
+            Assert.assertEquals(404, data.error?.status ?: 0)
+        }
+    }
+    @Test
+    fun updateSubscribe_success(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """
+                {
+                    "success": true,
+                    "response": {
+                        "subscribeId": 1,
+                        "title": "정컴 공지",
+                        "noticeLink": null,
+                        "isActive": true
+                    },
+                    "error": null
+                }
+                """.trimIndent()
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).updateSubscribe(
+                    subscribeId = subscribeId,
+                    subscribeUpdateRequestDTO = SubscribeUpdateRequestDTO("정컴 공지",  null)
+                )
+
+            // then
+            Assert.assertEquals(true, data.success)
+            Assert.assertEquals(1, data.response?.subscribeId ?: 0)
+            Assert.assertEquals("정컴 공지", data.response?.title ?: "")
+            Assert.assertEquals(null, data.response?.noticeLink)
+            Assert.assertEquals(true, data.response?.isActive)
+            Assert.assertEquals(null, data.error)
+        }
+    }
+    @Test
+    fun updateSubscribe_fail(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """{"success": false, "response": null, "error": {"message": "빈 구독 목록입니다.", "status": 400}}"""
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).updateSubscribe(
+                subscribeId = subscribeId,
+                subscribeUpdateRequestDTO = SubscribeUpdateRequestDTO("부산대 RSS 링크가 아닙니다.",  null)
+            )
+
+            // then
+            Assert.assertEquals(false, data.success)
+            Assert.assertEquals(null, data.response)
+            Assert.assertEquals(400, data.error?.status ?: 0)
+        }
+    }
+    @Test
+    fun deleteSubscribe_success(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """{"success": true, "response": null, "error": null}"""
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).deleteSubscribe(subscribeId = subscribeId)
+
+            // then
+            Assert.assertEquals(true, data.success)
+            Assert.assertEquals(null, data.response)
+            Assert.assertEquals(null, data.error)
+        }
+    }
+    @Test
+    fun deleteSubscribe_fail(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """{"success": false, "response": null, "error": {"message": "허가되지 않은 접근입니다.", "status": 403}}"""
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).deleteSubscribe(subscribeId = subscribeId)
+
+            // then
+            Assert.assertEquals(false, data.success)
+            Assert.assertEquals(null, data.response)
+            Assert.assertEquals(403, data.error?.status ?: 0)
+        }
+    }
+    @Test
+    fun updateActive_success(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """
+            {
+                "success": true,
+                "response": {
+                    "subscribeId": 1,
+                    "title": "정컴 공지",
+                    "noticeLink": null,
+                    "isActive": false
+                },
+                "error": null
+            }
+            """.trimIndent()
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).updateActive(subscribeId = subscribeId)
+
+            // then
+            Assert.assertEquals(true, data.success)
+            Assert.assertEquals(1, data.response?.subscribeId ?: 0)
+            Assert.assertEquals("정컴 공지", data.response?.title ?: "")
+            Assert.assertEquals(null, data.response?.noticeLink)
+            Assert.assertEquals(null, data.error)
+        }
+    }
+    @Test
+    fun updateActive_fail(){
+        runBlocking {
+            // given
+            val subscribeId = 1L
+            val content = """{"success": false, "response": null, "error": {"message": "존재하지 않는 구독입니다.", "status": 404}}"""
+
+            // when
+            val mock = getExceptionHttpClient(content)
+            val data = SubscribeDataSource(mock).updateActive(subscribeId = subscribeId)
+
+            // then
+            Assert.assertEquals(false, data.success)
+            Assert.assertEquals(null, data.response)
+            Assert.assertEquals(404, data.error?.status ?: 0)
+        }
+    }
+}

--- a/Ppap/app/src/test/java/com/jeongg/ppap/UserUnitTest.kt
+++ b/Ppap/app/src/test/java/com/jeongg/ppap/UserUnitTest.kt
@@ -1,20 +1,7 @@
-package com.jeongg.ppap.user
+package com.jeongg.ppap
 
 import com.jeongg.ppap.data.user.UserDataSource
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
-import io.ktor.http.headersOf
-import io.ktor.serialization.kotlinx.json.json
-import io.ktor.utils.io.ByteReadChannel
+import com.jeongg.ppap.util.getExceptionHttpClient
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
@@ -119,25 +106,5 @@ class UserUnitTest {
             Assert.assertEquals(400, data.error?.status ?: -1)
         }
     }
-    private fun getExceptionHttpClient(content: String): HttpClient{
-        return HttpClient(
-            MockEngine {
-                respond(
-                    content = ByteReadChannel(content),
-                    status = HttpStatusCode.OK,
-                    headers = headersOf(HttpHeaders.ContentType, "application/json")
-                )
-            }
-        ){
-            install(ContentNegotiation) {
-                json()
-            }
-            install(Logging){
-                level = LogLevel.ALL
-            }
-            defaultRequest {
-                contentType(ContentType.Application.Json)
-            }
-        }
-    }
+
 }

--- a/Ppap/app/src/test/java/com/jeongg/ppap/util/GetExceptionHttpClient.kt
+++ b/Ppap/app/src/test/java/com/jeongg/ppap/util/GetExceptionHttpClient.kt
@@ -1,0 +1,38 @@
+package com.jeongg.ppap.util
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+
+fun getExceptionHttpClient(content: String): HttpClient {
+    return HttpClient(
+        MockEngine {
+            respond(
+                content = ByteReadChannel(content),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+    ){
+        install(ContentNegotiation) {
+            json()
+        }
+        install(Logging){
+            level = LogLevel.ALL
+        }
+        defaultRequest {
+            contentType(ContentType.Application.Json)
+        }
+    }
+}


### PR DESCRIPTION
## API 연결
- 구독 생성
- 구독 목록 조회
- 구독 상세 조회
- 구독 수정
- 구독 삭제
- 구독 상태 변경

## 토큰 재발행 에러 해결
- 문제는... refreshTokenDTO였다. (변수명 잘못)
- 그리고 headers 특정하기 위해 `appendIfNameAbsent` 써야 했다...
- 이거 두개로 거의 3시간............
![image](https://github.com/PnuPostAlarmProject/android/assets/84652886/318d4d7c-165f-459d-8ddd-3bc10b3738bf)

## 테스트 코드 작성
> Mock ClientHttp를 만들어 간단하게 Unit Test 실시(각 케이스별로 성공, 실패 1개씩

close #17 